### PR TITLE
feat(utils): Add `fromNow` util

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ export interface IUtils<TDate> {
 
   /** Allow to customize displaying "am/pm" strings */
   getMeridiemText(ampm: "am" | "pm"): string;
+
+  /** Returns relative time from passed date */
+  fromNow(date: TDate): string;
 }
 ```
 

--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -152,4 +152,6 @@ export interface IUtils<TDate> {
 
   /** Allow to customize displaying "am/pm" strings */
   getMeridiemText(ampm: "am" | "pm"): string;
+  /** Returns relative time from passed date */
+  fromNow(date: TDate): string;
 }

--- a/packages/date-fns/src/index.ts
+++ b/packages/date-fns/src/index.ts
@@ -46,6 +46,7 @@ import startOfWeek from "date-fns/startOfWeek";
 import startOfYear from "date-fns/startOfYear";
 import { IUtils, DateIOFormats, Unit } from "@date-io/core/IUtils";
 import isWithinInterval from "date-fns/isWithinInterval";
+import formatRelative from "date-fns/formatRelative";
 import longFormatters from "date-fns/_lib/format/longFormatters";
 import defaultLocale from "date-fns/locale/en-US";
 
@@ -413,6 +414,11 @@ class DateFnsUtils implements IUtils<Date> {
 
     return years;
   };
+
+  public fromNow = (date: Date) => {
+    // TODO: Replace with `intlFormatDistance` once https://github.com/date-fns/date-fns/issues/1782 is closed
+    return formatRelative(new Date(), date, { locale: this.locale });
+  }
 }
 
 export default DateFnsUtils

--- a/packages/hijri/src/index.ts
+++ b/packages/hijri/src/index.ts
@@ -195,6 +195,10 @@ class MomentUtils extends DefaultMomentUtils {
 
     return years;
   };
+
+  public fromNow = (date: Moment) => {
+    return date.fromNow();
+  }
 }
 
 export default MomentUtils;

--- a/packages/moment/src/index.ts
+++ b/packages/moment/src/index.ts
@@ -358,6 +358,10 @@ class MomentUtils implements IUtils<defaultMoment.Moment> {
   public isWithinRange = (date: Moment, [start, end]: [Moment, Moment]) => {
     return date.isBetween(start, end, null, "[]");
   };
+
+  public fromNow = (date: Moment) => {
+    return date.fromNow();
+  }
 }
 
 export default MomentUtils


### PR DESCRIPTION
Closes #5

Used in `date-fns` the utility [`formatRelative`](https://date-fns.org/v2.25.0/docs/formatRelative) until https://github.com/date-fns/date-fns/pull/2173 is closed